### PR TITLE
feat(jsonrpc): implement clear signing for the attestation transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2749,6 +2749,7 @@ dependencies = [
  "serde",
  "serde_json",
  "starknet",
+ "starknet-core",
  "starknet-crypto",
  "thiserror 2.0.12",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ reqwest-websocket = { version = "0.4.4", features = ["json"] }
 serde = "1.0.219"
 serde_json = "1.0.140"
 starknet = "0.14.0"
+starknet-core = "0.13.0"
 starknet-crypto = "0.7.4"
 thiserror = "2.0.12"
 tokio = { version = "1.44.1", features = ["full"] }


### PR DESCRIPTION
The remote signer API now supports clear signing. This means that in addition to the transaction hash, complete transaction data is sent to the remote signer. We use the JSON-RPC 0.8.1 specification's INVOKE_TXN_V3 schema to send the transaction data.

To implement clear signing with starknet-rs, we had to duplicate some code from starknet-rs. Because the transaction data is _not_ available in the `Signer` trait, we had to implement our own `Account` that has access to all the details and can then use our own `AttestationSigner` trait to sign the transaction.