### PR TITLE
fix(signer): use a 60s timeout for remote signer requests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -152,7 +152,7 @@ async fn main() -> anyhow::Result<()> {
         signer::AttestationSigner::new_local(signer)
     } else if let Some(url) = config.remote_signer_url {
         tracing::info!(%url, "Using remote signer");
-        signer::AttestationSigner::new_remote(url)
+        signer::AttestationSigner::new_remote(url).context("Creating remote signer")?
     } else {
         anyhow::bail!("Either local_signer or remote_signer_url must be specified");
     };

--- a/src/signer.rs
+++ b/src/signer.rs
@@ -34,8 +34,8 @@ impl AttestationSigner {
         Self::Local(wallet)
     }
 
-    pub fn new_remote(url: url::Url) -> Self {
-        Self::Remote(RemoteSigner::new(url))
+    pub fn new_remote(url: url::Url) -> anyhow::Result<Self> {
+        Ok(Self::Remote(RemoteSigner::new(url)?))
     }
 
     pub async fn sign(
@@ -66,11 +66,13 @@ pub struct RemoteSigner {
 
 impl RemoteSigner {
     /// Constructs [`RemoteSigner`] from a [`reqwest::Client`].
-    pub fn new(url: url::Url) -> Self {
-        Self {
+    pub fn new(url: url::Url) -> anyhow::Result<Self> {
+        Ok(Self {
             url,
-            client: reqwest::Client::new(),
-        }
+            client: reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(60))
+                .build()?,
+        })
     }
 }
 


### PR DESCRIPTION
Reqwest defaults to no timeout, which can lead to problems.