### PR TITLE
fix(jsonrpc): create JSON-RPC client with a HTTP timeout of 30 seconds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1136,6 +1136,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.2",
  "tower-service",
+ "webpki-roots 0.26.8",
 ]
 
 [[package]]
@@ -2068,7 +2069,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.25.4",
  "winreg",
 ]
 
@@ -2097,7 +2098,6 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.24",
- "rustls-native-certs",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -2112,6 +2112,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 0.26.8",
  "windows-registry",
 ]
 
@@ -2744,6 +2745,7 @@ dependencies = [
  "futures-util",
  "metrics",
  "metrics-exporter-prometheus",
+ "reqwest 0.11.27",
  "reqwest 0.12.15",
  "reqwest-websocket",
  "serde",
@@ -3366,6 +3368,15 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "which"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ metrics = "0.24.1"
 metrics-exporter-prometheus = "0.16.2"
 reqwest = { version = "0.12.15", default-features = false, features = [
     "json",
-    "rustls-tls-native-roots",
+    "rustls-tls",
 ] }
 reqwest-websocket = { version = "0.4.4", features = ["json"] }
 serde = "1.0.219"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ clap = { version = "4.5.34", features = ["derive", "env"] }
 futures-util = "0.3.31"
 metrics = "0.24.1"
 metrics-exporter-prometheus = "0.16.2"
+# This is a workaround for starknet-rs using reqwest 0.11.
+reqwest_starknet-rs = { package = "reqwest", version = "0.11", default-features = false, features = [
+    "rustls-tls",
+] }
 reqwest = { version = "0.12.15", default-features = false, features = [
     "json",
     "rustls-tls",

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY . .
 RUN cargo build --release
 
 FROM debian:bookworm-slim AS runner
-RUN apt-get update && apt-get install -y ca-certificates tini && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y tini && rm -rf /var/lib/apt/lists/*
 RUN groupadd --gid 1000 starknet && useradd --uid 1000 --gid 1000 starknet
 
 COPY --from=rust-builder /src/target/release/starknet-validator-attestation /usr/local/bin/

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -197,12 +197,15 @@ impl StarknetRpcClient {
         url: Url,
         staking_contract_address: Felt,
         attestation_contract_address: Felt,
-    ) -> Self {
-        StarknetRpcClient {
-            client: JsonRpcClient::new(HttpTransport::new(url)),
+    ) -> anyhow::Result<Self> {
+        let http_client = reqwest_starknet_rs::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()?;
+        Ok(StarknetRpcClient {
+            client: JsonRpcClient::new(HttpTransport::new_with_client(url, http_client)),
             staking_contract_address,
             attestation_contract_address,
-        }
+        })
     }
 
     async fn get_attestation_window(&self) -> anyhow::Result<u16> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,7 +125,8 @@ async fn main() -> anyhow::Result<()> {
         config.node_url.clone(),
         config.staking_contract_address,
         config.attestation_contract_address,
-    );
+    )
+    .context("Creating JSON-RPC client")?;
 
     // Initialize Prometheus metrics
     let prometheus_handle = metrics_exporter_prometheus::PrometheusBuilder::new()


### PR DESCRIPTION
The default HTTP transport in starknet-providers creates a HTTP client with no timeouts. Since this could block our state machine indefinitely we now set a timeout of 30 seconds.

Unfortunately starknet-rs uses an older version of reqwest so we have to add an additional dependency to our Cargo.toml to be able to set the timeout. This is a temporary workaround until `starknet-rs` upgrades to a newer version of `reqwest`.