### PR TITLE
fix: fix some lint issues

### DIFF
--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -128,8 +128,7 @@ impl Client for StarknetRpcClient {
                 },
                 BlockId::Tag(BlockTag::Pending),
             )
-            .await
-            .unwrap();
+            .await?;
 
         Ok(result == vec![Felt::ONE])
     }
@@ -151,8 +150,7 @@ impl Client for StarknetRpcClient {
                 },
                 BlockId::Tag(BlockTag::Pending),
             )
-            .await
-            .unwrap();
+            .await?;
 
         let attestation_window = self
             .get_attestation_window()
@@ -214,13 +212,12 @@ impl StarknetRpcClient {
             .call(
                 FunctionCall {
                     contract_address: self.attestation_contract_address,
-                    entry_point_selector: get_selector_from_name("attestation_window").unwrap(),
+                    entry_point_selector: get_selector_from_name("attestation_window")?,
                     calldata: vec![],
                 },
                 BlockId::Tag(BlockTag::Pending),
             )
-            .await
-            .unwrap();
+            .await?;
 
         let attestation_window = result[0]
             .try_into()

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,15 +141,12 @@ async fn main() -> anyhow::Result<()> {
     // Set up signer
     let signer = if config.local_signer {
         tracing::info!("Using local signer");
-        let signer = LocalWallet::from_signing_key(SigningKey::from_secret_scalar(
-            Felt::from_hex(
-                &std::env::var("VALIDATOR_ATTESTATION_OPERATIONAL_PRIVATE_KEY").expect(
-                    "VALIDATOR_ATTESTATION_OPERATIONAL_PRIVATE_KEY environment variable should be \
+        let signer = LocalWallet::from_signing_key(SigningKey::from_secret_scalar(Felt::from_hex(
+            &std::env::var("VALIDATOR_ATTESTATION_OPERATIONAL_PRIVATE_KEY").expect(
+                "VALIDATOR_ATTESTATION_OPERATIONAL_PRIVATE_KEY environment variable should be \
                      set to the private key",
-                ),
-            )
-            .unwrap(),
-        ));
+            ),
+        )?));
         signer::AttestationSigner::new_local(signer)
     } else if let Some(url) = config.remote_signer_url {
         tracing::info!(%url, "Using remote signer");

--- a/src/state.rs
+++ b/src/state.rs
@@ -22,7 +22,7 @@ pub struct AttestationParams {
 }
 
 impl AttestationParams {
-    pub fn in_window(&self, block_number: u64) -> std::cmp::Ordering {
+    pub fn in_window(&self, block_number: u64) -> Ordering {
         use std::cmp::Ordering;
 
         if block_number < self.start_of_attestation_window {

--- a/src/state.rs
+++ b/src/state.rs
@@ -532,23 +532,6 @@ mod tests {
     }
 
     impl crate::jsonrpc::Client for MockClient {
-        async fn get_attestation_info(
-            &self,
-            _operational_address: Felt,
-        ) -> Result<AttestationInfo, ClientError> {
-            self.attestation_sent
-                .store(false, std::sync::atomic::Ordering::Relaxed);
-
-            Ok(self.attestation_info.clone())
-        }
-
-        async fn get_block_hash(&self, _block_number: u64) -> Result<Felt, ClientError> {
-            self.block_hash_queried
-                .store(true, std::sync::atomic::Ordering::Relaxed);
-
-            Ok(BLOCK_HASH)
-        }
-
         async fn attest(
             &self,
             operational_address: Felt,
@@ -571,6 +554,23 @@ mod tests {
             assert_eq!(self.attestation_info.staker_address, staker_address);
 
             Ok(false)
+        }
+
+        async fn get_attestation_info(
+            &self,
+            _operational_address: Felt,
+        ) -> Result<AttestationInfo, ClientError> {
+            self.attestation_sent
+                .store(false, std::sync::atomic::Ordering::Relaxed);
+
+            Ok(self.attestation_info.clone())
+        }
+
+        async fn get_block_hash(&self, _block_number: u64) -> Result<Felt, ClientError> {
+            self.block_hash_queried
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+
+            Ok(BLOCK_HASH)
         }
     }
 }


### PR DESCRIPTION
Including some incorrect uses of `.unwrap()` that might lead to panics upon encountering certain JSON-RPC errors.