### PR TITLE
chore(github): bump release binary builder to Ubuntu 22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
             matrix:
               include:
                 - target: x86_64-unknown-linux-gnu
-                  os: ubuntu-20.04
+                  os: ubuntu-22.04
         runs-on: ${{ matrix.os }}
         steps:
             - uses: actions/checkout@v4


### PR DESCRIPTION
Ubuntu 20.04 is no longer available.