### PR TITLE
fix(signer): make remote signing API compatible with Juno

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,9 @@ There are two options for signing attestation transactions sent by the tool.
 
 The API should expose a single `/sign` endpoint:
 
-- POST `/sign`: should return the signature for the transaction hash and transaction values received as its input. The `transaction` object should follow the [INVOKE_TXN_V3](https://github.com/starkware-libs/starknet-specs/blob/a2d10fc6cbaddbe2d3cf6ace5174dd0a306f4885/api/starknet_api_openrpc.json#L2621) schema from the JSON-RPC specification. Example request body:
+- POST `/sign`: should return the signature for the chain id and transaction values received as its input. The `transaction` object should follow the [INVOKE_TXN_V3](https://github.com/starkware-libs/starknet-specs/blob/a2d10fc6cbaddbe2d3cf6ace5174dd0a306f4885/api/starknet_api_openrpc.json#L2621) schema from the JSON-RPC specification (the signature field is ignored). Example request body:
   ```json
   {
-      "transaction_hash": "0xdeadbeef",
       "transaction": {
           "type": "INVOKE",
           "sender_address": "0x2e216b191ac966ba1d35cb6cfddfaf9c12aec4dfe869d9fa6233611bb334ee9",
@@ -82,7 +81,8 @@ The API should expose a single `/sign` endpoint:
           "account_deployment_data": [],
           "nonce_data_availability_mode": "L1",
           "fee_data_availability_mode": "L1"
-      }
+      },
+      "chain_id": "0x534e5f5345504f4c4941"
   }
   ```
   Response should contain the ECDSA signature values `r` and `s` in an array:
@@ -95,7 +95,7 @@ The API should expose a single `/sign` endpoint:
   }
   ```
 
-A toy implementation of the API is available [here](./examples/signer.rs).
+An example implementation of the API is available [here](./examples/signer.rs).
 
 ## Monitoring
 

--- a/examples/signer.rs
+++ b/examples/signer.rs
@@ -5,7 +5,7 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use starknet::signers::SigningKey;
 use starknet_core::types::BroadcastedInvokeTransactionV3;
-use starknet_crypto::Felt;
+use starknet_crypto::{Felt, PoseidonHasher, poseidon_hash_many};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -16,8 +16,8 @@ struct PublicKeyResponse {
 
 #[derive(Deserialize)]
 struct SignHashRequest {
-    transaction_hash: Felt,
     transaction: BroadcastedInvokeTransactionV3,
+    chain_id: Felt,
 }
 
 #[derive(Serialize)]
@@ -62,10 +62,13 @@ async fn main() {
                 move |Json(payload): Json<SignHashRequest>| {
                     let state = Arc::clone(&state);
                     async move {
-                        tracing::info!(transaction=?payload.transaction, "Signing transaction");
+                        let transaction_hash = transaction_hash(&payload.transaction, payload.chain_id);
+                        tracing::info!(transaction=?payload.transaction, chain_id=?payload.chain_id, ?transaction_hash, "Signing transaction");
+
+
                         // Sign the hash
                         let signing_key = state.lock().await;
-                        let signature = signing_key.sign(&payload.transaction_hash).unwrap();
+                        let signature = signing_key.sign(&transaction_hash).unwrap();
 
                         Json(SignHashResponse {
                             signature: [signature.r, signature.s],
@@ -79,4 +82,147 @@ async fn main() {
         .await
         .unwrap();
     axum::serve(listener, app).await.unwrap();
+}
+
+/// Cairo string for "invoke"
+const PREFIX_INVOKE: Felt = Felt::from_raw([
+    513398556346534256,
+    18446744073709551615,
+    18446744073709551615,
+    18443034532770911073,
+]);
+
+/// 2 ^ 128 + 3
+const QUERY_VERSION_THREE: Felt = Felt::from_raw([
+    576460752142432688,
+    18446744073709551584,
+    17407,
+    18446744073700081569,
+]);
+
+// Mostly a copy of the `RawExecutionV3::transaction_hash()` method from the starknet-rs.
+fn transaction_hash(tx: &BroadcastedInvokeTransactionV3, chain_id: Felt) -> Felt {
+    let mut hasher = PoseidonHasher::new();
+
+    hasher.update(PREFIX_INVOKE);
+    hasher.update(if tx.is_query {
+        QUERY_VERSION_THREE
+    } else {
+        Felt::THREE
+    });
+    hasher.update(tx.sender_address);
+
+    hasher.update({
+        let mut fee_hasher = PoseidonHasher::new();
+
+        fee_hasher.update(tx.tip.into());
+
+        let mut resource_buffer = [
+            0, 0, b'L', b'1', b'_', b'G', b'A', b'S', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ];
+        resource_buffer[8..(8 + 8)]
+            .copy_from_slice(&tx.resource_bounds.l1_gas.max_amount.to_be_bytes());
+        resource_buffer[(8 + 8)..]
+            .copy_from_slice(&tx.resource_bounds.l1_gas.max_price_per_unit.to_be_bytes());
+        fee_hasher.update(Felt::from_bytes_be(&resource_buffer));
+
+        let mut resource_buffer = [
+            0, 0, b'L', b'2', b'_', b'G', b'A', b'S', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ];
+        resource_buffer[8..(8 + 8)]
+            .copy_from_slice(&tx.resource_bounds.l2_gas.max_amount.to_be_bytes());
+        resource_buffer[(8 + 8)..]
+            .copy_from_slice(&tx.resource_bounds.l2_gas.max_price_per_unit.to_be_bytes());
+        fee_hasher.update(Felt::from_bytes_be(&resource_buffer));
+
+        let mut resource_buffer = [
+            0, b'L', b'1', b'_', b'D', b'A', b'T', b'A', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ];
+        resource_buffer[8..(8 + 8)]
+            .copy_from_slice(&tx.resource_bounds.l1_data_gas.max_amount.to_be_bytes());
+        resource_buffer[(8 + 8)..].copy_from_slice(
+            &tx.resource_bounds
+                .l1_data_gas
+                .max_price_per_unit
+                .to_be_bytes(),
+        );
+        fee_hasher.update(Felt::from_bytes_be(&resource_buffer));
+
+        fee_hasher.finalize()
+    });
+
+    hasher.update(poseidon_hash_many(&tx.paymaster_data));
+
+    hasher.update(chain_id);
+    hasher.update(tx.nonce);
+
+    // Hard-coded L1 DA mode for nonce and fee
+    hasher.update(Felt::ZERO);
+
+    hasher.update(poseidon_hash_many(&tx.account_deployment_data));
+
+    hasher.update(poseidon_hash_many(&tx.calldata));
+
+    hasher.finalize()
+}
+
+#[cfg(test)]
+mod tests {
+    use starknet::macros::felt;
+    use starknet_core::{
+        chain_id,
+        types::{
+            BroadcastedInvokeTransactionV3, DataAvailabilityMode, ResourceBounds,
+            ResourceBoundsMapping,
+        },
+    };
+
+    use super::transaction_hash;
+
+    #[test]
+    fn test_transaction_hash() {
+        let tx = BroadcastedInvokeTransactionV3 {
+            sender_address: felt!(
+                "0x2e216b191ac966ba1d35cb6cfddfaf9c12aec4dfe869d9fa6233611bb334ee9"
+            ),
+            calldata: vec![
+                felt!("0x1"),
+                felt!("0x3f32e152b9637c31bfcf73e434f78591067a01ba070505ff6ee195642c9acfb"),
+                felt!("0x37446750a403c1b4014436073cf8d08ceadc5b156ac1c8b7b0ca41a0c9c1c54"),
+                felt!("0x1"),
+                felt!("0x7979a0a0a175d7e738e8e9ba6fa6d48f680d67758f719390eee58e790819836"),
+            ],
+            signature: vec![],
+            nonce: felt!("0x106"),
+            resource_bounds: ResourceBoundsMapping {
+                l1_gas: ResourceBounds {
+                    max_amount: 0,
+                    max_price_per_unit: 0x51066a69ad72c,
+                },
+                l1_data_gas: ResourceBounds {
+                    max_amount: 0x600,
+                    max_price_per_unit: 0x1254,
+                },
+                l2_gas: ResourceBounds {
+                    max_amount: 0xf00000,
+                    max_price_per_unit: 0x308c5bff6,
+                },
+            },
+            tip: 0,
+            paymaster_data: vec![],
+            account_deployment_data: vec![],
+            nonce_data_availability_mode: DataAvailabilityMode::L1,
+            fee_data_availability_mode: DataAvailabilityMode::L1,
+            is_query: false,
+        };
+        let chain_id = chain_id::SEPOLIA;
+        let tx_hash = transaction_hash(&tx, chain_id);
+        assert_eq!(
+            tx_hash,
+            felt!("0x382a7406fe3931ba1faf00d1eaa36b7c8770b8d185b091b730ecdb4dba5f3ce"),
+        );
+    }
 }

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -277,7 +277,10 @@ where
         let tx_hash = execution.transaction_hash(self.chain_id, self.address, query_only, self);
         let transaction = self.get_invoke_request(execution, query_only);
 
-        let signature = self.signer.sign(&tx_hash, transaction).await?;
+        let signature = self
+            .signer
+            .sign(&tx_hash, transaction, self.chain_id)
+            .await?;
 
         Ok(vec![signature.r, signature.s])
     }

--- a/src/signer.rs
+++ b/src/signer.rs
@@ -42,10 +42,11 @@ impl AttestationSigner {
         &self,
         hash: &Felt,
         transaction: BroadcastedInvokeTransactionV3,
+        chain_id: Felt,
     ) -> Result<Signature, SignError> {
         let signature = match self {
             Self::Local(wallet) => wallet.sign_hash(hash).await?,
-            Self::Remote(signer) => signer.sign(hash, transaction).await?,
+            Self::Remote(signer) => signer.sign(transaction, chain_id).await?,
         };
         Ok(signature)
     }
@@ -79,15 +80,15 @@ impl RemoteSigner {
 impl RemoteSigner {
     async fn sign(
         &self,
-        hash: &Felt,
         transaction: BroadcastedInvokeTransactionV3,
+        chain_id: Felt,
     ) -> Result<Signature, SignError> {
         let signature = self
             .client
             .post(self.url.join("/sign").unwrap())
             .json(&SignRequest {
-                transaction_hash: *hash,
                 transaction,
+                chain_id,
             })
             .send()
             .await
@@ -109,8 +110,8 @@ impl RemoteSigner {
 
 #[derive(Serialize)]
 struct SignRequest {
-    transaction_hash: Felt,
     transaction: BroadcastedInvokeTransactionV3,
+    chain_id: Felt,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
Instead of sending a `transaction_hash` along with the transaction, the clear signing API now receives the `chain_id` and the `transaction` only. This forces the signer implementation to recalculate the transaction hash value itself (for which it needs the chain ID).