### PR TITLE
feat: add defaults for staking/attestation contract addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,12 @@ You can either use the Docker image we publish on [GitHub](https://github.com/eq
 docker run -it --rm --network host \
   -e VALIDATOR_ATTESTATION_OPERATIONAL_PRIVATE_KEY="0xdeadbeef" \
   ghcr.io/eqlabs/starknet-validator-attestation \
-  --staking-contract-address 0x03745ab04a431fc02871a139be6b93d9260b0ff3e779ad9c8b377183b23109f1 \
-  --attestation-contract-address 0x03f32e152b9637c31bfcf73e434f78591067a01ba070505ff6ee195642c9acfb \
   --staker-operational-address 0x02e216b191ac966ba1d35cb6cfddfaf9c12aec4dfe869d9fa6233611bb334ee9 \
   --node-url http://localhost:9545/rpc/v0_8 \
   --local-signer
 ```
 
 Each CLI option can also be set via environment variables. Please check the output of `starknet-validator-attestation --help` for more information.
-
-The private key of the operational account _must_ be set via the `VALIDATOR_ATTESTATION_OPERATIONAL_PRIVATE_KEY` environment variable.
 
 Log level defaults to `info`. Verbose logging can be enabled by setting the `RUST_LOG` environment variable to `debug`.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is a tool for attesting validators on Starknet. Implements the attestation 
 
 ## Installation
 
-You can either use the Docker image we publish on [GitHub](https://github.com/eqlabs/starknet-validator-attestation/pkgs/container/starknet-validator-attestation) or compile the source code from this repository. Compilation requires Rust 1.85+.
+You can either use the Docker image we publish on [GitHub](https://github.com/eqlabs/starknet-validator-attestation/pkgs/container/starknet-validator-attestation), the binaries on our [release page](https://github.com/eqlabs/starknet-validator-attestation/releases/latest) or compile the source code from this repository. Compilation requires Rust 1.85+.
 
 
 ## Running


### PR DESCRIPTION
To simplify configuration this PR adds default values for staking and attestation contract addresses for Sepolia (and partially for mainnet).

This works by querying the chain ID via JSON-RPC and using the [well-known addresses](https://docs.starknet.io/resources/chain-info/#staking) both for Sepolia and mainnet.

Addresses specified explicitly override these defaults.