### PR TITLE
fix(main): add anyhow context when parsing private key env var

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -157,12 +157,15 @@ async fn main() -> anyhow::Result<()> {
     // Set up signer
     let signer = if config.local_signer {
         tracing::info!("Using local signer");
-        let signer = LocalWallet::from_signing_key(SigningKey::from_secret_scalar(Felt::from_hex(
-            &std::env::var("VALIDATOR_ATTESTATION_OPERATIONAL_PRIVATE_KEY").expect(
-                "VALIDATOR_ATTESTATION_OPERATIONAL_PRIVATE_KEY environment variable should be \
+        let signer = LocalWallet::from_signing_key(SigningKey::from_secret_scalar(
+            Felt::from_hex(
+                &std::env::var("VALIDATOR_ATTESTATION_OPERATIONAL_PRIVATE_KEY").expect(
+                    "VALIDATOR_ATTESTATION_OPERATIONAL_PRIVATE_KEY environment variable should be \
                      set to the private key",
-            ),
-        )?));
+                ),
+            )
+            .context("Parsing private key")?,
+        ));
         signer::AttestationSigner::new_local(signer)
     } else if let Some(url) = config.remote_signer_url {
         tracing::info!(%url, "Using remote signer");


### PR DESCRIPTION
When misconfiguring the environment variable the error message printed was just telling the user that parsing a felt has failed:

```
13:17:57.047655Z  INFO starknet_validator_attestation: Using local signer
Error: Failed to create Felt from string
```

This commit adds a context to the error message, so that the user can see that the error is related to the private key environment variable:

```
2025-04-29T13:40:34.961888Z  INFO starknet_validator_attestation: Using local signer
Error: Parsing private key

Caused by:
    Failed to create Felt from string
```