### PR TITLE
feat: add support for non-ECDSA remote signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The API should expose a single `/sign` endpoint:
       "chain_id": "0x534e5f5345504f4c4941"
   }
   ```
-  Response should contain the ECDSA signature values `r` and `s` in an array:
+  Response should contain the signature as an array:
   ```json
   {
       "signature": [

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -277,7 +277,7 @@ where
             .sign(&tx_hash, transaction, self.chain_id)
             .await?;
 
-        Ok(vec![signature.r, signature.s])
+        Ok(signature)
     }
 
     async fn sign_declaration_v3(


### PR DESCRIPTION
When using a remote signer, the attestation tool should not force that the signature returned is an ECDSA signature (`r` and `s` values).

Since on the remote signer API we're expecting the signature as an array of felts, the attestation tool should just take this array directly and use it as a signature for the transaction.

Some account contracts _do_ support non-ECDSA signatures, or use a signature encoding scheme that is not compatible with the ECDSA scheme used by the OpenZeppelin account contract. (Braavos for example uses a signature that's longer than just two felts.)