### PR TITLE
chore: log detailed transaction submission error

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -204,7 +204,7 @@ impl State {
                                 .increment(1);
                             }
                             Err(err) => {
-                                tracing::error!(error = %err, "Failed to send attestation transaction");
+                                tracing::error!(error = ?err, "Failed to send attestation transaction");
                                 metrics::counter!(
                                     "validator_attestation_attestation_failure_count"
                                 )


### PR DESCRIPTION
The `Debug` implementation for `anyhow::Error` logs the whole error chain, so instead of just logging that the transaction submission failed we now also log the _actual_ underlying error in detail (like: attestation already done, or attestation out of window).