### PR TITLE
fix(docker): add ca-certificates package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY . .
 RUN cargo build --release
 
 FROM debian:bookworm-slim AS runner
-RUN apt-get update && apt-get install -y tini && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y tini ca-certificates && rm -rf /var/lib/apt/lists/*
 RUN groupadd --gid 1000 starknet && useradd --uid 1000 --gid 1000 starknet
 
 COPY --from=rust-builder /src/target/release/starknet-validator-attestation /usr/local/bin/


### PR DESCRIPTION
Websocket subscriptions use native TLS certificate roots with rustls, so we need to install the ca-certificates package for TLS connections to work from within the container.