### PR TITLE
feat(metrics): add new metric for missed epochs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Available metrics are:
 - `validator_attestation_attestation_submitted_count`: Number of attestations submitted by the validator.
 - `validator_attestation_attestation_failure_count`: Number of attestation transaction submission failures.
 - `validator_attestation_attestation_confirmed_count`: Number of attestations confirmed by the network.
+- `validator_attestation_missed_epochs_count`: Number of epochs with no successful attestation.
 
 The chain ID of the network is exposed as the `network` label on all metrics.
 

--- a/src/metrics_exporter.rs
+++ b/src/metrics_exporter.rs
@@ -88,4 +88,10 @@ fn describe_metrics() {
         metrics::Unit::Count,
         "Number of confirmed attestations"
     );
+    let _ = metrics::counter!("validator_attestation_missed_epochs_count");
+    metrics::describe_counter!(
+        "validator_attestation_missed_epochs_count",
+        metrics::Unit::Count,
+        "Number of epochs with no successful attestation"
+    );
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -222,6 +222,7 @@ impl State {
                 }
                 Ordering::Greater => {
                     // We're past the attestation window
+                    metrics::counter!("validator_attestation_missed_epochs_count").increment(1);
                     State::WaitingForNextEpoch { attestation_info }
                 }
             },


### PR DESCRIPTION
The new metrics counts the number of epochs where we have failed to attest.

Closes #26 