### PR TITLE
feat(attestation): improve logging

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -107,6 +107,8 @@ impl State {
                 .get_attestation_info(operational_address)
                 .await
                 .context("Getting attestation info")?;
+            let expected_attestation_block =
+                attestation_info.calculate_expected_attestation_block();
             tracing::info!(
                 staker_address=?attestation_info.staker_address,
                 operational_address=?attestation_info.operational_address,
@@ -115,6 +117,7 @@ impl State {
                 epoch_start=%attestation_info.current_epoch_starting_block,
                 epoch_length=%attestation_info.epoch_len,
                 attestation_window=%attestation_info.attestation_window,
+                expected_attestation_block=%expected_attestation_block,
                 "New epoch started"
             );
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -241,6 +241,7 @@ impl State {
                 }
                 Ordering::Greater => {
                     // We're past the attestation window
+                    tracing::warn!("Attestation window expired without submitting attestation");
                     metrics::counter!("validator_attestation_missed_epochs_count").increment(1);
                     State::WaitingForNextEpoch { attestation_info }
                 }


### PR DESCRIPTION
Edit: this PR has been split into two: the logging improvements, which is kept here. State machine related changes will be done in a different PR, independently of this one.

This PR improves how `StarknetRpcClient` manages nonces and makes the attestation state transitions more robust.

### StarknetRpcClient

* Added `Mutex` to safely manage `current_nonce`, so transactions don't clash when multiple are sent in a short time.

### State Machine

* Replaced the `Attesting` state with two clearer states: `AttestationWindowActive` and `AttestationSubmitted`. This helps avoid duplicate submissions and better reflects what's happening.
* Improved error handling for expired attestation windows and added metrics for missed epochs.
* After a successful attestation, the state now correctly moves to `WaitingForNextEpoch`.

### Tests

* Updated test cases to match the new states and transitions to ensure everything still works as expected.