### PR TITLE
Fix missing missed_epochs_count metric

### DIFF
--- a/src/metrics_exporter.rs
+++ b/src/metrics_exporter.rs
@@ -94,4 +94,6 @@ fn describe_metrics() {
         metrics::Unit::Count,
         "Number of epochs with no successful attestation"
     );
+
+    metrics::counter!("validator_attestation_missed_epochs_count").absolute(0);
 }


### PR DESCRIPTION
## Problem
The `validator_attestation_missed_epochs_count` metric was not visible in the metrics endpoint because Prometheus counters are only exported after they have been incremented at least once.

This meant that validators with perfect uptime (no missed epochs) would not show this metric at all, making monitoring difficult.

## Solution
Initialize the `validator_attestation_missed_epochs_count` counter with zero value during metrics setup using `.absolute(0)`.

## Result
- The metric is now visible immediately with value `0`
- Counter will still increment correctly when epochs are actually missed
- Monitoring systems can now track this metric consistently for all validators