### PR TITLE
Add STRK balance metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Available metrics are:
 - `validator_attestation_attestation_failure_count`: Number of attestation transaction submission failures.
 - `validator_attestation_attestation_confirmed_count`: Number of attestations confirmed by the network.
 - `validator_attestation_missed_epochs_count`: Number of epochs with no successful attestation.
+- `validator_attestation_operational_account_balance_strk`: Current STRK token balance of the operational account.
 
 The chain ID of the network is exposed as the `network` label on all metrics.
 

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -203,9 +203,7 @@ impl Client for StarknetRpcClient {
             )
             .await?;
 
-        let balance: u128 = result[0]
-            .try_into()
-            .context("Converting STRK balance")?;
+        let balance: u128 = result[0].try_into().context("Converting STRK balance")?;
         Ok(balance)
     }
 }

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -75,12 +75,14 @@ pub trait Client {
         operational_address: Felt,
     ) -> Result<AttestationInfo, ClientError>;
     async fn get_block_hash(&self, block_number: u64) -> Result<Felt, ClientError>;
+    async fn get_strk_balance(&self, account_address: Felt) -> Result<u128, ClientError>;
 }
 
 pub struct StarknetRpcClient {
     client: JsonRpcClient<HttpTransport>,
     staking_contract_address: Felt,
     attestation_contract_address: Felt,
+    strk_contract_address: Felt,
 }
 
 impl Client for StarknetRpcClient {
@@ -186,6 +188,26 @@ impl Client for StarknetRpcClient {
             }
         }
     }
+
+    async fn get_strk_balance(&self, account_address: Felt) -> Result<u128, ClientError> {
+        let result = self
+            .client
+            .call(
+                FunctionCall {
+                    contract_address: self.strk_contract_address,
+                    entry_point_selector: get_selector_from_name("balance_of")
+                        .context("Getting balance_of selector")?,
+                    calldata: vec![account_address],
+                },
+                BlockId::Tag(BlockTag::Pending),
+            )
+            .await?;
+
+        let balance: u128 = result[0]
+            .try_into()
+            .context("Converting STRK balance")?;
+        Ok(balance)
+    }
 }
 
 impl StarknetRpcClient {
@@ -193,11 +215,13 @@ impl StarknetRpcClient {
         client: JsonRpcClient<HttpTransport>,
         staking_contract_address: Felt,
         attestation_contract_address: Felt,
+        strk_contract_address: Felt,
     ) -> Self {
         StarknetRpcClient {
             client,
             staking_contract_address,
             attestation_contract_address,
+            strk_contract_address,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -397,27 +397,30 @@ fn strk_contract_address_from_chain_id(chain_id: Felt) -> anyhow::Result<Felt> {
         felt!("0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d");
 
     // Support mainnet and sepolia (both use same contract address currently)
-    if chain_id == starknet::core::chain_id::MAINNET || chain_id == starknet::core::chain_id::SEPOLIA {
+    if chain_id == starknet::core::chain_id::MAINNET
+        || chain_id == starknet::core::chain_id::SEPOLIA
+    {
         Ok(STRK_CONTRACT_ADDRESS)
     } else {
-        anyhow::bail!("STRK contract address is not configured for chain ID {}", chain_id)
+        anyhow::bail!(
+            "STRK contract address is not configured for chain ID {}",
+            chain_id
+        )
     }
 }
 
 // Helper function to update operational account balance
-async fn update_operational_balance<C: Client>(
-    client: &C,
-    operational_address: Felt,
-) {
+async fn update_operational_balance<C: Client>(client: &C, operational_address: Felt) {
     match client.get_strk_balance(operational_address).await {
         Ok(balance) => {
             // Convert to floating point STRK (divide by 10^18)
             let balance_strk = balance as f64 / 1e18;
-            metrics::gauge!("validator_attestation_operational_account_balance_strk").set(balance_strk);
-            tracing::debug!("Updated operational account balance: {} STRK", balance_strk);
+            metrics::gauge!("validator_attestation_operational_account_balance_strk")
+                .set(balance_strk);
+            tracing::debug!(%balance_strk, "Updated operational account balance");
         }
         Err(err) => {
-            tracing::warn!("Failed to get operational account STRK balance: {}", err);
+            tracing::warn!(error=%err, "Failed to get operational account STRK balance");
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,11 +141,13 @@ async fn main() -> anyhow::Result<()> {
     let chain_id = client.chain_id().await.context("Getting chain ID")?;
     let (staking_contract_address, attestation_contract_address) =
         contract_addresses_from_config(&config, chain_id)?;
+    let strk_contract_address = strk_contract_address_from_chain_id(chain_id)?;
 
     let client = jsonrpc::StarknetRpcClient::new(
         client,
         staking_contract_address,
         attestation_contract_address,
+        strk_contract_address,
     );
 
     // Initialize Prometheus metrics
@@ -243,6 +245,9 @@ async fn main() -> anyhow::Result<()> {
         "Current attestation info"
     );
     let mut state = state::State::from_attestation_info(attestation_info);
+
+    // Initialize operational account balance metric
+    update_operational_balance(&client, config.staker_operational_address).await;
 
     // Handle TERM and INT signals
     let mut term_signal = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
@@ -384,4 +389,35 @@ fn contract_addresses_from_config(config: &Config, chain_id: Felt) -> anyhow::Re
         )?;
 
     Ok((staking_contract_address, attestation_contract_address))
+}
+
+fn strk_contract_address_from_chain_id(chain_id: Felt) -> anyhow::Result<Felt> {
+    // STRK contract address (same for both mainnet and testnet currently)
+    const STRK_CONTRACT_ADDRESS: Felt =
+        felt!("0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d");
+
+    // Support mainnet and sepolia (both use same contract address currently)
+    if chain_id == starknet::core::chain_id::MAINNET || chain_id == starknet::core::chain_id::SEPOLIA {
+        Ok(STRK_CONTRACT_ADDRESS)
+    } else {
+        anyhow::bail!("STRK contract address is not configured for chain ID {}", chain_id)
+    }
+}
+
+// Helper function to update operational account balance
+async fn update_operational_balance<C: Client>(
+    client: &C,
+    operational_address: Felt,
+) {
+    match client.get_strk_balance(operational_address).await {
+        Ok(balance) => {
+            // Convert to floating point STRK (divide by 10^18)
+            let balance_strk = balance as f64 / 1e18;
+            metrics::gauge!("validator_attestation_operational_account_balance_strk").set(balance_strk);
+            tracing::debug!("Updated operational account balance: {} STRK", balance_strk);
+        }
+        Err(err) => {
+            tracing::warn!("Failed to get operational account STRK balance: {}", err);
+        }
+    }
 }

--- a/src/metrics_exporter.rs
+++ b/src/metrics_exporter.rs
@@ -94,4 +94,10 @@ fn describe_metrics() {
         metrics::Unit::Count,
         "Number of epochs with no successful attestation"
     );
+    let _ = metrics::gauge!("validator_attestation_operational_account_balance_strk");
+    metrics::describe_gauge!(
+        "validator_attestation_operational_account_balance_strk",
+        metrics::Unit::Count,
+        "Current STRK balance of the operational account"
+    );
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -117,6 +117,16 @@ impl State {
                 attestation_window=%attestation_info.attestation_window,
                 "New epoch started"
             );
+
+            // Update operational account balance at the start of new epoch
+            if let Ok(balance) = client.get_strk_balance(operational_address).await {
+                let balance_strk = balance as f64 / 1e18;
+                metrics::gauge!("validator_attestation_operational_account_balance_strk").set(balance_strk);
+                tracing::debug!("Updated operational account balance for new epoch {}: {} STRK", attestation_info.epoch_id, balance_strk);
+            } else {
+                tracing::warn!("Failed to update operational account balance for new epoch");
+            }
+            
             State::from_attestation_info(attestation_info)
         };
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -222,15 +222,6 @@ impl State {
                             }
                         };
 
-                        // Update operational account balance after any attestation attempt
-                        // Even if RPC returns error, the transaction might have succeeded on-chain
-                        if let Ok(balance) = client.get_strk_balance(attestation_info.operational_address).await {
-                            let balance_strk = balance as f64 / 1e18;
-                            metrics::gauge!("validator_attestation_operational_account_balance_strk").set(balance_strk);
-                            tracing::debug!("Updated operational account balance after attestation attempt: {} STRK", balance_strk);
-                        } else {
-                            tracing::warn!("Failed to update operational account balance after attestation attempt");
-                        }
                         State::Attesting {
                             attestation_info,
                             attestation_params,

--- a/src/state.rs
+++ b/src/state.rs
@@ -202,13 +202,6 @@ impl State {
                                     "validator_attestation_attestation_submitted_count"
                                 )
                                 .increment(1);
-
-                                // Update operational account balance after spending STRK on attestation
-                                if let Ok(balance) = client.get_strk_balance(attestation_info.operational_address).await {
-                                    let balance_strk = balance as f64 / 1e18;
-                                    metrics::gauge!("validator_attestation_operational_account_balance_strk").set(balance_strk);
-                                    tracing::debug!("Updated operational account balance after attestation: {} STRK", balance_strk);
-                                }
                             }
                             Err(err) => {
                                 tracing::error!(error = ?err, "Failed to send attestation transaction");
@@ -218,6 +211,16 @@ impl State {
                                 .increment(1);
                             }
                         };
+
+                        // Update operational account balance after any attestation attempt
+                        // Even if RPC returns error, the transaction might have succeeded on-chain
+                        if let Ok(balance) = client.get_strk_balance(attestation_info.operational_address).await {
+                            let balance_strk = balance as f64 / 1e18;
+                            metrics::gauge!("validator_attestation_operational_account_balance_strk").set(balance_strk);
+                            tracing::debug!("Updated operational account balance after attestation attempt: {} STRK", balance_strk);
+                        } else {
+                            tracing::warn!("Failed to update operational account balance after attestation attempt");
+                        }
                         State::Attesting {
                             attestation_info,
                             attestation_params,

--- a/src/state.rs
+++ b/src/state.rs
@@ -121,12 +121,17 @@ impl State {
             // Update operational account balance at the start of new epoch
             if let Ok(balance) = client.get_strk_balance(operational_address).await {
                 let balance_strk = balance as f64 / 1e18;
-                metrics::gauge!("validator_attestation_operational_account_balance_strk").set(balance_strk);
-                tracing::debug!("Updated operational account balance for new epoch {}: {} STRK", attestation_info.epoch_id, balance_strk);
+                metrics::gauge!("validator_attestation_operational_account_balance_strk")
+                    .set(balance_strk);
+                tracing::debug!(
+                    epoch_id=%attestation_info.epoch_id,
+                    %balance_strk,
+                    "Updated operational account balance for new epoch",
+                );
             } else {
                 tracing::warn!("Failed to update operational account balance for new epoch");
             }
-            
+
             State::from_attestation_info(attestation_info)
         };
 


### PR DESCRIPTION
## Closes #33

Adds a new Prometheus metric `validator_attestation_operational_account_balance_strk` to monitor the current STRK balance of the operational account.

### Problem
Currently stakers need to manually monitor their operational account balance to avoid attestation failures due to insufficient funds for transaction fees.

### Solution
- Added `get_strk_balance()` method to query STRK token balance via ERC20 contract
- New metric updates on startup and at the start of each new epoch
- Simplified STRK contract addresses (same for mainnet and sepolia)
- Added proper error handling and logging

### Changes
- **New metric**: `validator_attestation_operational_account_balance_strk` (gauge, in STRK units)
- **Efficient updates**: Balance refreshed on startup and once per epoch only
- **Test support**: Mock implementation for unit tests

This enables stakers to set up alerts when operational account balance gets low, preventing attestation failures