### PR TITLE
fix validator_attestation_missed_epochs_count metric bug

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -209,33 +209,8 @@ impl State {
                 }
                 Ordering::Greater => {
                     // We're past the attestation window
-                    // Check if attestation was already done for this epoch before marking as missed
-                    match client
-                        .attestation_done_in_current_epoch(attestation_info.staker_address)
-                        .await
-                    {
-                        Ok(false) => {
-                            tracing::warn!(
-                                "Attestation window expired without submitting attestation"
-                            );
-                            metrics::counter!("validator_attestation_missed_epochs_count")
-                                .increment(1);
-                        }
-                        Ok(true) => {
-                            tracing::info!(
-                                "Attestation window expired but attestation was already completed on this epoch"
-                            );
-                        }
-                        Err(error) => {
-                            tracing::error!(
-                                ?error,
-                                "Failed to check attestation status, assuming missed"
-                            );
-                            metrics::counter!("validator_attestation_missed_epochs_count")
-                                .increment(1);
-                        }
-                    }
-
+                    Self::ckeck_and_mark_epoch_as_missed(client, attestation_info.staker_address)
+                        .await;
                     State::WaitingForNextEpoch { attestation_info }
                 }
             },
@@ -313,34 +288,11 @@ impl State {
                     }
                     Ordering::Greater => {
                         // Check if attestation was actually confirmed before marking epoch as missed
-                        match client
-                            .attestation_done_in_current_epoch(attestation_info.staker_address)
-                            .await
-                        {
-                            Ok(false) => {
-                                tracing::warn!(
-                                    ?transaction_hash,
-                                    "Attestation window expired without confirmation"
-                                );
-                                metrics::counter!("validator_attestation_missed_epochs_count")
-                                    .increment(1);
-                            }
-                            Ok(true) => {
-                                tracing::info!(
-                                    ?transaction_hash,
-                                    "Attestation window expired but attestation was already completed on this epoch"
-                                );
-                            }
-                            Err(error) => {
-                                tracing::error!(
-                                    ?error,
-                                    ?transaction_hash,
-                                    "Failed to check attestation status, assuming missed"
-                                );
-                                metrics::counter!("validator_attestation_missed_epochs_count")
-                                    .increment(1);
-                            }
-                        }
+                        Self::ckeck_and_mark_epoch_as_missed(
+                            client,
+                            attestation_info.staker_address,
+                        )
+                        .await;
 
                         State::WaitingForNextEpoch { attestation_info }
                     }
@@ -417,6 +369,36 @@ impl State {
                 metrics::counter!("validator_attestation_attestation_failure_count").increment(1);
 
                 Err(err.into())
+            }
+        }
+    }
+
+    async fn ckeck_and_mark_epoch_as_missed<C: crate::jsonrpc::Client + Send + Sync + 'static>(
+        client: &C,
+        staker_address: Felt,
+    ) {
+        // Check if attestation was already done for this epoch before marking as missed
+        match client
+            .attestation_done_in_current_epoch(staker_address)
+            .await
+        {
+            Ok(false) => {
+                tracing::warn!(
+                    "Attestation window expired without submitting or confirming an attestation"
+                );
+                metrics::counter!("validator_attestation_missed_epochs_count").increment(1);
+            }
+            Ok(true) => {
+                tracing::info!(
+                    "Attestation window expired but attestation was already completed on this epoch"
+                );
+            }
+            Err(error) => {
+                tracing::error!(
+                    ?error,
+                    "Failed to check attestation status, assuming missed"
+                );
+                metrics::counter!("validator_attestation_missed_epochs_count").increment(1);
             }
         }
     }


### PR DESCRIPTION
## Problem

The `validator_attestation_missed_epochs_count` metric was incorrectly incrementing when the attestator restarted or updated after an attestation window had expired, even if the attestation was already completed successfully.

<img width="1888" height="119" alt="image" src="https://github.com/user-attachments/assets/b341e1a7-d368-43a8-9de8-9858f9e97ed5" />

**Reproduction scenario:**
1. Validator successfully attests a block
2. Wait 20-30 blocks 
3. Restart the attestator
4. The metric incorrectly shows the epoch as "missed" even though it was actually attested

## Root Cause

The state machine was incrementing the missed epochs counter without checking if an attestation was already completed for the current epoch. This happened in two places:

1. In `Attesting` state when attestation window expires
2. In `AttestationSubmitted` state when waiting for confirmation times out

## Solution

Added `attestation_done_in_current_epoch()` checks before incrementing the missed epochs counter in both locations:

- **Lines ~207-208**: `Attesting` state transition
- **Lines ~291-293**: `AttestationSubmitted` state transition

Now the counter only increments for genuinely missed epochs, not for epochs that were already successfully attested.

## Testing

- All unit tests pass
- Logic verified in both state transition paths