### PR TITLE
fix typo after #PR39

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -209,7 +209,7 @@ impl State {
                 }
                 Ordering::Greater => {
                     // We're past the attestation window
-                    Self::ckeck_and_mark_epoch_as_missed(client, attestation_info.staker_address)
+                    Self::check_and_mark_epoch_as_missed(client, attestation_info.staker_address)
                         .await;
                     State::WaitingForNextEpoch { attestation_info }
                 }
@@ -288,7 +288,7 @@ impl State {
                     }
                     Ordering::Greater => {
                         // Check if attestation was actually confirmed before marking epoch as missed
-                        Self::ckeck_and_mark_epoch_as_missed(
+                        Self::check_and_mark_epoch_as_missed(
                             client,
                             attestation_info.staker_address,
                         )
@@ -373,7 +373,7 @@ impl State {
         }
     }
 
-    async fn ckeck_and_mark_epoch_as_missed<C: crate::jsonrpc::Client + Send + Sync + 'static>(
+    async fn check_and_mark_epoch_as_missed<C: crate::jsonrpc::Client + Send + Sync + 'static>(
         client: &C,
         staker_address: Felt,
     ) {


### PR DESCRIPTION
## Fix typo in function name

Fixed typo: `ckeck_and_submit_attestation` → `check_and_submit_attestation`

**What was changed:**
- Corrected spelling error in function name (missing 'h' in 'check')

**Impact:**
- No functional changes, code readability improvement