### PR TITLE
update min_attestation window

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -12,8 +12,8 @@ use crate::{
 ///
 /// The block hash to attest must be available at the start of the attestation
 /// window. On Starknet, block hash of block N becomes available at block N +
-/// 10.
-const MIN_ATTESTATION_WINDOW: u64 = 10;
+/// 11.
+const MIN_ATTESTATION_WINDOW: u64 = 11;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct AttestationParams {


### PR DESCRIPTION
## Problem

Fixes premature attestation transaction submission that could lead to sequencer rejection.

### Issue Details:

1. **Premature submission**: System was sending attestations on block N+10 when protocol expects them on N+11
2. **Sequencer rejection**: Transactions were sometimes rejected as "premature" by the sequencer. This is not critical since the program immediately makes another attempt to send the attestation transaction which succeeds
3. **Metric increase**: This led to an increase in "validator_attestation_attestation_failure_count" metric by 1
4. **Network performance impact**: The issue occurred intermittently - when network performance was high, it rarely caused errors, but reduced overall system reliability

### Technical Details:

- **Before**: `MIN_ATTESTATION_WINDOW = 10` → attestation on N+10
- **After**: `MIN_ATTESTATION_WINDOW = 11` → attestation on N+11
- **Protocol compliance**: System now works with attestation window 11-40 as required by protocol

### Impact:

✅ **Eliminates transaction rejections** by sequencer
✅ **Reduces Attestation Failures metric**
✅ **Improves attestation reliability**
✅ **Complies with protocol requirements** (window 11-40)

### Testing:

- Minimal and safe change
- Doesn't break existing logic
- Complies with PM requirements for "attestation window 11-40"