### PR TITLE
improve transaction hash logging

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -235,7 +235,7 @@ impl State {
                             },
                             TransactionStatus::Rejected => {
                                 tracing::warn!(
-                                    %transaction_hash,
+                                    ?transaction_hash,
                                     "Attestation transaction was rejected"
                                 );
 
@@ -258,7 +258,7 @@ impl State {
                                     == TransactionExecutionStatus::Reverted =>
                             {
                                 tracing::warn!(
-                                    %transaction_hash,
+                                    ?transaction_hash,
                                     "Attestation transaction has reverted"
                                 );
                                 metrics::counter!(


### PR DESCRIPTION
# Commit Message:
```
Improve transaction hash logging format in warn messages
```

# Extended Description:

## Problem

Transaction hashes in error logs were displayed as decimal numbers instead of hexadecimal format, making them difficult to read and debug.

## Before
```
transaction_hash=5124521129427308090043450866476784141884011571369475561623939911145490936811
```

## After  
```
transaction_hash=0x3с9b456732327abc6def0123786789abcdef0123456789abcdef01234567891234
```

## Changes

- Changed `%transaction_hash` to `?transaction_hash` in warn logging
- Affects warn "Attestation transaction has reverted" messages
- Makes transaction hashes readable and copy-pasteable for debugging
