### PR TITLE
improve block hash logging

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -343,7 +343,7 @@ impl State {
         attestation_info: &AttestationInfo,
         attestation_params: &AttestationParams,
     ) -> anyhow::Result<Felt> {
-        tracing::debug!(block_hash=%attestation_params.block_hash, "Sending attestation transaction");
+        tracing::debug!(block_hash=?attestation_params.block_hash, "Sending attestation transaction");
         let result = client
             .attest(
                 attestation_info.operational_address,


### PR DESCRIPTION
Same like #43 
```
2025-08-08T07:41:09.617096Z DEBUG starknet_validator_attestation::state: Sending attestation transaction block_hash=1692128594018699135270783997152132567241324676163502873655836942529590157564
```