### PR TITLE
feat(metrics): add new metric for total confirmations observed

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ Available metrics are:
 - `validator_attestation_last_attestation_timestamp_seconds`: Timestamp of the last attestation.
 - `validator_attestation_attestation_submitted_count`: Number of attestations submitted by the validator.
 - `validator_attestation_attestation_failure_count`: Number of attestation transaction submission failures.
-- `validator_attestation_attestation_confirmed_count`: Number of attestations confirmed by the network.
+- `validator_attestation_attestation_confirmed_count`: Number of attestations submitted that have been confirmed by the network.
+- `validator_attestation_attestation_confirmations_observed_count`: Number of total attestation confirmations (includes attestation _not_ submitted by this tool).
 - `validator_attestation_missed_epochs_count`: Number of epochs with no successful attestation.
 - `validator_attestation_operational_account_balance_strk`: Current STRK token balance of the operational account.
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,14 @@
+default:
+    just --summary --unsorted
+
+test $RUST_BACKTRACE="1" *args="":
+    cargo test --workspace --all-targets {{args}}
+
+check:
+    cargo check --workspace --all-targets --locked
+
+clippy *args="":
+    cargo clippy --workspace --all-targets --locked {{args}} -- -D warnings -D rust_2018_idioms
+
+fmt:
+    cargo fmt  --all

--- a/src/metrics_exporter.rs
+++ b/src/metrics_exporter.rs
@@ -100,4 +100,10 @@ fn describe_metrics() {
         metrics::Unit::Count,
         "Current STRK balance of the operational account"
     );
+    let _ = metrics::counter!("validator_attestation_attestation_confirmations_observed_count");
+    metrics::describe_counter!(
+        "validator_attestation_attestation_confirmations_observed_count",
+        metrics::Unit::Count,
+        "Number of total attestation confirmations observed"
+    );
 }


### PR DESCRIPTION
The new metric tracks the total number of attestation confirmation events received. Useful in cases where a starker is running multiple instances of the attestation tool.
